### PR TITLE
Fix a typo and bring compatibility with Tailwind 2.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const path = require('path');
 
 const execa = require('execa');
-const Listr = require('Listr');
+const Listr = require('listr');
 const inquirer = require('inquirer');
 
 const dependencies = [

--- a/index.js
+++ b/index.js
@@ -11,10 +11,10 @@ const inquirer = require('inquirer');
 
 const dependencies = [
   '@fullhuman/postcss-purgecss',
-  'autoprefixer',
+  'autoprefixer@^9',
   'parcel-bundler',
-  'postcss',
-  'tailwindcss',
+  'postcss@^7',
+  'tailwindcss@compat',
 ];
 
 const questions = [


### PR DESCRIPTION
Hi,

I was trying to use the package when I found a little typo in the import of `Listr`. Also I modified the versions of Tailwind, Autoprefixer and PostCSS to maintain compatibility with the new Tailwind 2.0. The new version needs PostCSS 8 but Parcel has some issues with this version. So, the Tailwind team made a PostCSS 7 compatibility build for cases like this. Here is the documentation: https://tailwindcss.com/docs/installation#post-css-7-compatibility-build

Thanks for your work :)